### PR TITLE
Fix CMake warnings due to minimum version being too low

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Install tracks
 file(GLOB TRACKS "[^.]*")
@@ -7,4 +7,3 @@ foreach(track ${TRACKS})
 		install(DIRECTORY ${track} DESTINATION "${SHARE_INSTALL}/tracks")
 	endif()
 endforeach()
-


### PR DESCRIPTION
`tracks` counterpart of https://github.com/stuntrally/stuntrally/pull/57 (should be merged at the same time).

CMake 3.22.2 warns about CMake versions prior to 2.8.12 no longer being supported soon. Increasing the minimum version requirement fixes those warnings.

2.8.12 is a very old version by now, and even Debian oldoldstable (stretch) has a more recent version (3.7.2, 3.16.3 in backports).